### PR TITLE
fix: Chrome composing issue

### DIFF
--- a/src/components/Textarea.tsx
+++ b/src/components/Textarea.tsx
@@ -235,11 +235,11 @@ export const Textarea = React.forwardRef(
     /**
      * 変換中かどうか（isComposing）を適切に取得する
      * - Safariだとkeydownの前にcompositionEndが発火される
-     *   - keydown時のisComposingの値が適切ではない（変換確定のEnterキーでhandleKeyDownがcomposing:falseとして呼ばれてしまう）
-     *   - keyupイベントで変換終了を確認することで対応
+     *   => 変換確定時のkeydownにおいてisComposingの値が適切ではない（変換確定のEnterキーでhandleKeyDownがcomposing:falseとして呼ばれてしまう）
+     *   => keyupイベントで変換終了を確認することで対応
      * - Chromeだとkeyupイベントの後にcompositionStartが発火される
-     *   - キーを離す前にEnterを押されると変換中であると認識されない
-     *   - keydownイベントで変換開始を確認することで対応
+     *   => キーを離す前にEnterを押されると変換中であると認識されない
+     *   => keydownイベントで変換開始を確認することで対応
      */
     useEffect(() => {
       const checkComposingStart = (e: KeyboardEvent) => {


### PR DESCRIPTION
# 概要
- Chrome 91で確認
- bulletListにおいてIMEが動くキーを押下した際、そのキーを離す前にEnterキーを押すと、変換が確定するのではなくリストが改行されてしまう
  - 例えば「あ」キーを離す前に、Enterで確定しようとすると、リストが改行されてしまう
  - 突然発生するようになったので最近のChromeでのみ再現する可能性あり

# 原因
Chromeだとkeyupイベントの後にcompositionStartイベントが発火されるため、キーを離す前にEnterを押されると変換中であると認識されない

# 対処法
以下のようにする

- Safariだと`keydown`の前に`compositionEnd`が発火されるため、変換確定時の`keydown`イベントの`isComposing`の値が適切ではない（変換確定のEnterキーで`handleKeyDown`が`composing:false`として呼ばれてしまう）
  - => `keyup`イベントで変換終了を確認することで対応
- Chromeだと`keyup`イベントの後に`compositionStart`が発火されるため、キーを離す前にEnterを押されると変換中であると認識されない
  - => `keydown`イベントで変換開始を確認することで対応